### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Watson - Language Translator V3
 
-Publisher: Splunk \
-Connector Version: 1.0.4 \
-Product Vendor: IBM \
-Product Name: Watson Language Translator V3 \
+Publisher: Splunk <br>
+Connector Version: 1.0.4 <br>
+Product Vendor: IBM <br>
+Product Name: Watson Language Translator V3 <br>
 Minimum Product Version: 5.1.0
 
 Leverage IBM Watson for language translation using API version V3
@@ -31,17 +31,17 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[get language](#action-get-language) - Identifies the language of a given body of text \
-[list languages](#action-list-languages) - List languages that can be used for translation \
-[list translations](#action-list-translations) - List languages translation models \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[get language](#action-get-language) - Identifies the language of a given body of text <br>
+[list languages](#action-list-languages) - List languages that can be used for translation <br>
+[list translations](#action-list-translations) - List languages translation models <br>
 [translate text](#action-translate-text) - Translate text from one language to another
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -56,7 +56,7 @@ No Output
 
 Identifies the language of a given body of text
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -85,7 +85,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List languages that can be used for translation
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -108,7 +108,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List languages translation models
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -140,7 +140,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Translate text from one language to another
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **True**
 
 If model_id is specified the source and target parameters are ignored.<br>If the action fails with the error <i>Model not found</i>, it means the service cannot translate the text as is and a customized model needs to be created. Please see the Watson Language Translator documentation for instructions on creating a customized model.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Update NOTICE file with updated dependencies
 * Apply pre-commit fixes
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13

--- a/watsonv3.json
+++ b/watsonv3.json
@@ -7,7 +7,7 @@
     "logo": "logo_ibmwatson.svg",
     "logo_dark": "logo_ibmwatson_dark.svg",
     "product_name": "Watson Language Translator V3",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "product_version_regex": ".*",
     "publisher": "Splunk",

--- a/watsonv3.json
+++ b/watsonv3.json
@@ -522,5 +522,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)