### PR TITLE
fix: verify Watson server certificates by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2021-2025 Splunk Inc.
+   Copyright (c) 2021-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Watson - Language Translator V3
-Copyright (c) 2021-2025 Splunk Inc.
+Copyright (c) 2021-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Updated connector development tooling.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 
-* - Updated connector development tooling.
+* Updated connector development tooling.
 * Enabled TLS certificate verification by default for Watson API requests. Existing assets retain their saved setting and should be reviewed after upgrade.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * - Updated connector development tooling.
+* Enabled TLS certificate verification by default for Watson API requests. Existing assets retain their saved setting and should be reviewed after upgrade.

--- a/watsonv3.json
+++ b/watsonv3.json
@@ -11,7 +11,7 @@
     "fips_compliant": true,
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2021-2025 Splunk Inc.",
+    "license": "Copyright (c) 2021-2026 Splunk Inc.",
     "app_version": "1.0.5",
     "utctime_updated": "2025-09-05T16:36:37.900624Z",
     "package_name": "phantom_watsonlanguagev3",

--- a/watsonv3.json
+++ b/watsonv3.json
@@ -31,7 +31,7 @@
         "verify_server_cert": {
             "description": "Verify server certificate",
             "data_type": "boolean",
-            "default": false,
+            "default": true,
             "order": 1
         },
         "api_key": {

--- a/watsonv3_connector.py
+++ b/watsonv3_connector.py
@@ -137,7 +137,7 @@ class WatsonLanguageTranslatorV3Connector(BaseConnector):
         url = self._base_url + "/v3" + endpoint
 
         try:
-            r = request_func(url, auth=("apikey", self._api_key), verify=config.get(consts.WATSONV3_JSON_VERIFY_SERVER_CERT, False), **kwargs)
+            r = request_func(url, auth=("apikey", self._api_key), verify=config.get(consts.WATSONV3_JSON_VERIFY_SERVER_CERT, True), **kwargs)
         except Exception as e:
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {e!s}"), resp_json)
 

--- a/watsonv3_connector.py
+++ b/watsonv3_connector.py
@@ -1,6 +1,6 @@
 # File: watsonv3_connector.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/watsonv3_consts.py
+++ b/watsonv3_consts.py
@@ -1,6 +1,6 @@
 # File: watsonv3_consts.py
 #
-# Copyright (c) 2021-2025 Splunk Inc.
+# Copyright (c) 2021-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- enable TLS certificate verification by default in both the manifest and runtime fallback
- call out persisted settings for existing assets in the release note
- refresh the connector tooling baseline to dev-cicd-tools v2.2.4

## Tracking

- PAPP-38204
- PSAAS-30726
- Parent epic: ESPM-5228

## Validation

- local pre-commit: passed
- hosted pre-commit and compile: pending

## AI assistance

- [x] This pull request was created entirely with AI assistance.

Written by Codex.