### PR TITLE
fix!: require an explicit Watson TLS opt-out [Codex]

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This table lists the configuration variables required to operate Watson - Langua
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
 **base_url** | required | string | Watson URL |
-**verify_server_cert** | optional | boolean | Verify server certificate |
+**allow_insecure_tls** | optional | boolean | Explicitly disable Watson server certificate verification. Leave disabled for secure TLS. |
 **api_key** | required | password | Watson API key |
 **version** | optional | string | Watson current API version (YYYY-MM-DD) |
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,4 @@
 **Unreleased**
+
+* Replaced the legacy certificate-verification field with an explicit insecure-TLS opt-out that defaults to disabled.
+* Existing assets that intentionally require unverified TLS must enable the new opt-out after upgrade; legacy saved false values are not inherited.

--- a/tests/test_tls_policy.py
+++ b/tests/test_tls_policy.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import ast
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TLSPolicyTests(unittest.TestCase):
+    def test_manifest_requires_a_new_explicit_opt_out(self):
+        manifest = json.loads((ROOT / "watsonv3.json").read_text())
+        configuration = manifest["configuration"]
+
+        self.assertNotIn("verify_server_cert", configuration)
+        self.assertFalse(configuration["allow_insecure_tls"]["default"])
+
+    def test_requests_verify_unless_new_opt_out_is_enabled(self):
+        source = (ROOT / "watsonv3_connector.py").read_text()
+        tree = ast.parse(source)
+        handler = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_make_rest_call")
+        handler_source = ast.get_source_segment(source, handler)
+
+        self.assertIn("not bool(config.get(consts.WATSONV3_JSON_ALLOW_INSECURE_TLS, False))", handler_source)
+        self.assertIn("verify=verify_server_cert", handler_source)
+        self.assertNotIn("WATSONV3_JSON_VERIFY_SERVER_CERT", handler_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/watsonv3.json
+++ b/watsonv3.json
@@ -28,10 +28,10 @@
             "required": true,
             "order": 0
         },
-        "verify_server_cert": {
-            "description": "Verify server certificate",
+        "allow_insecure_tls": {
+            "description": "Explicitly disable Watson server certificate verification. Leave disabled for secure TLS.",
             "data_type": "boolean",
-            "default": true,
+            "default": false,
             "order": 1
         },
         "api_key": {

--- a/watsonv3_connector.py
+++ b/watsonv3_connector.py
@@ -135,9 +135,10 @@ class WatsonLanguageTranslatorV3Connector(BaseConnector):
 
         # Create a URL to connect to
         url = self._base_url + "/v3" + endpoint
+        verify_server_cert = not bool(config.get(consts.WATSONV3_JSON_ALLOW_INSECURE_TLS, False))
 
         try:
-            r = request_func(url, auth=("apikey", self._api_key), verify=config.get(consts.WATSONV3_JSON_VERIFY_SERVER_CERT, True), **kwargs)
+            r = request_func(url, auth=("apikey", self._api_key), verify=verify_server_cert, **kwargs)
         except Exception as e:
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {e!s}"), resp_json)
 

--- a/watsonv3_consts.py
+++ b/watsonv3_consts.py
@@ -14,4 +14,4 @@
 # and limitations under the License.
 GET_DEFAULT_VERSION = "2018-05-01"
 DEFAULT_TIMEOUT = 30
-WATSONV3_JSON_VERIFY_SERVER_CERT = "verify_server_cert"
+WATSONV3_JSON_ALLOW_INSECURE_TLS = "allow_insecure_tls"


### PR DESCRIPTION
## Summary

- replace the inherited certificate-verification field with a new explicit insecure-TLS opt-out
- default the new opt-out to disabled so legacy saved false values cannot silently carry forward
- require administrators who intentionally need unverified TLS to enable the new field after upgrade
- add focused migration and runtime-policy tests

## Release impact

This is a major-version change because `verify_server_cert` is replaced by `allow_insecure_tls`. The commit contains a semantic-release `BREAKING CHANGE` footer, and the upgrade procedure is documented in the release notes.

## Tracking

- [PAPP-38204](https://splunk.atlassian.net/browse/PAPP-38204)
- [PSAAS-30726](https://splunk.atlassian.net/browse/PSAAS-30726)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)
- Provenance: VULN-93451

## Validation

- `python3 -m unittest tests/test_tls_policy.py`
- `python3 -m py_compile watsonv3_connector.py`
- `pre-commit run --all-files`
- hosted pre-commit and compile pending
- exact `psirt-code-validation` recovery review pending

Merge strategy: merge commit only; do not squash.

Written by Codex.
